### PR TITLE
fix: add jq dependency

### DIFF
--- a/vanilla-zephyr/Dockerfile.ci
+++ b/vanilla-zephyr/Dockerfile.ci
@@ -34,6 +34,7 @@ RUN \
   gcc \
   git \
   gperf \
+  jq \
   lcov \
   libcairo2-dev \
   libmagic1 \


### PR DESCRIPTION
# Description

The image was missing the [jq](https://jqlang.github.io/jq/) utility, which is required by the codechecker-diff.sh script in firmware repositories.

![image](https://github.com/user-attachments/assets/83dec58a-a211-4f8e-ae2e-3500d8b5ca0b)

## Areas of interest for the reviewer

Nothing special.

## Checklist

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] ~~I added/updated source code documentation for all newly added or changed functions.~~ No new or changed functions.
- [x] ~~I updated all customer-facing technical documentation.~~ not applicable

## After-review steps

- Reviewer can merge and delete the branch.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
